### PR TITLE
fix RSS Feed toJSON instance

### DIFF
--- a/Text/Feed/RSS.hs
+++ b/Text/Feed/RSS.hs
@@ -120,7 +120,7 @@ instance ToJSON Feed where
     , "docs"           .= feedDocs
     , "timeToLive"     .= feedTimeToLive
     , "image"          .= feedImage
-    , "items"          .= feedItems ]
+    , "item"          .= feedItems ]
 
 -- | An RSS item.
 


### PR DESCRIPTION
the `toJSON` instance for the RSS Feed had a field like `items` but the template uses `item`